### PR TITLE
Refactor handler to remove repetitive args

### DIFF
--- a/backend/internal/handlers/activities.go
+++ b/backend/internal/handlers/activities.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/anish-chanda/cadent/backend/internal/compression"
-	"github.com/anish-chanda/cadent/backend/internal/db"
 	"github.com/anish-chanda/cadent/backend/internal/geo"
 	"github.com/anish-chanda/cadent/backend/internal/logger"
 	"github.com/anish-chanda/cadent/backend/internal/models"
@@ -107,14 +106,14 @@ type GetActivitiesResponse struct {
 	Activities []ActivityResult `json:"activities"`
 }
 
-func HandleCreateActivity(database db.Database, valhallaClient *valhalla.Client, objectStore store.ObjectStore, log logger.ServiceLogger) http.HandlerFunc {
+func (h *Handler) HandleCreateActivity() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// TODO: Use go routines to optimize stream processing performance
 		ctx := context.Background()
 
 		var req CreateActivityRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			log.Error("Failed to decode request", err)
+			h.log.Error("Failed to decode request", err)
 			http.Error(w, "Invalid request body", http.StatusBadRequest)
 			return
 		}
@@ -151,9 +150,9 @@ func HandleCreateActivity(database db.Database, valhallaClient *valhalla.Client,
 		}
 
 		// Check idempotency
-		exists, err := database.CheckIdempotency(ctx, req.ClientActivityID.String())
+		exists, err := h.database.CheckIdempotency(ctx, req.ClientActivityID.String())
 		if err != nil {
-			log.Error("Failed to check idempotency", err)
+			h.log.Error("Failed to check idempotency", err)
 			http.Error(w, "Internal server error", http.StatusInternalServerError)
 			return
 		}
@@ -163,16 +162,16 @@ func HandleCreateActivity(database db.Database, valhallaClient *valhalla.Client,
 		}
 
 		// Get authenticated user ID
-		userID, err := getAuthenticatedUserID(ctx, r, database, log)
+		userID, err := h.getAuthenticatedUserID(ctx, r)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusUnauthorized)
 			return
 		}
 
-		log.Debug(fmt.Sprintf("Processing activity for user: %s", userID))
+		h.log.Debug(fmt.Sprintf("Processing activity for user: %s", userID))
 		// Validate activity_type enum before database insertion to return 400
 		if req.ActivityType != string(models.ActivityTypeRun) && req.ActivityType != string(models.ActivityTypeRoadBike) {
-			log.Error("Invalid activity type", fmt.Errorf("unsupported activity_type: %s", req.ActivityType))
+			h.log.Error("Invalid activity type", fmt.Errorf("unsupported activity_type: %s", req.ActivityType))
 			http.Error(w, fmt.Sprintf("Invalid activity_type: %s. Supported types: run, road_bike", req.ActivityType), http.StatusBadRequest)
 			return
 		}
@@ -180,7 +179,7 @@ func HandleCreateActivity(database db.Database, valhallaClient *valhalla.Client,
 		polyline, totalDistance, bounds := processGPSData(req.Samples)
 
 		// Get elevation data from Valhalla
-		elevationData, elevationHeights := getElevationDataAndHeights(ctx, valhallaClient, polyline, log)
+		elevationData, elevationHeights := getElevationDataAndHeights(ctx, h.valhallaClient, polyline, h.log)
 
 		// Calculate time-based metrics
 		elapsedSeconds := calculateElapsedSeconds(req.Samples)
@@ -194,7 +193,7 @@ func HandleCreateActivity(database db.Database, valhallaClient *valhalla.Client,
 
 		// Validate stream alignment (all arrays should have same length)
 		if err := validateStreamAlignment(fullStream, len(req.Samples)); err != nil {
-			log.Error("Stream alignment validation failed", err)
+			h.log.Error("Stream alignment validation failed", err)
 			http.Error(w, "Internal stream processing error", http.StatusInternalServerError)
 			return
 		}
@@ -206,37 +205,37 @@ func HandleCreateActivity(database db.Database, valhallaClient *valhalla.Client,
 		// Create compressed medium LOD streams
 		activityStreams, err := createCompressedStreams(activity.ID, keepIndices, fullStream)
 		if err != nil {
-			log.Error("Failed to create compressed streams", err)
+			h.log.Error("Failed to create compressed streams", err)
 			http.Error(w, "Failed to process stream data", http.StatusInternalServerError)
 			return
 		}
 
 		// Create and store FIT file
-		if err := createAndStoreFITFile(ctx, activity, req.Samples, objectStore, log); err != nil {
-			log.Error("Failed to create FIT file", err)
+		if err := createAndStoreFITFile(ctx, activity, req.Samples, h.objectStore, h.log); err != nil {
+			h.log.Error("Failed to create FIT file", err)
 			http.Error(w, "Failed to create FIT file", http.StatusInternalServerError)
 			return
 		}
 
 		// Save activity to database
-		if err := database.CreateActivity(ctx, activity); err != nil {
-			log.Error("Failed to save activity to database", err)
+		if err := h.database.CreateActivity(ctx, activity); err != nil {
+			h.log.Error("Failed to save activity to database", err)
 			http.Error(w, "Failed to save activity", http.StatusInternalServerError)
 			return
 		}
 
 		// Save activity streams to database
 		if len(activityStreams) > 0 {
-			if err := database.CreateActivityStreams(ctx, activityStreams); err != nil {
-				log.Error("Failed to save activity streams to database", err)
+			if err := h.database.CreateActivityStreams(ctx, activityStreams); err != nil {
+				h.log.Error("Failed to save activity streams to database", err)
 				// Log error but don't fail the request since main activity was saved
-				log.Info("Activity created successfully but streams failed to save")
+				h.log.Info("Activity created successfully but streams failed to save")
 			} else {
-				log.Debug(fmt.Sprintf("Successfully saved %d streams for activity: %s", len(activityStreams), activity.ID.String()))
+				h.log.Debug(fmt.Sprintf("Successfully saved %d streams for activity: %s", len(activityStreams), activity.ID.String()))
 			}
 		}
 
-		log.Debug(fmt.Sprintf("Created activity: %s for user: %s", activity.ID.String(), userID))
+		h.log.Debug(fmt.Sprintf("Created activity: %s for user: %s", activity.ID.String(), userID))
 
 		// Build and return response
 		result := createActivityResult(activity)
@@ -246,28 +245,27 @@ func HandleCreateActivity(database db.Database, valhallaClient *valhalla.Client,
 	}
 }
 
-// Helper function to extract and validate authenticated user ID
-func getAuthenticatedUserID(ctx context.Context, r *http.Request, database db.Database, log logger.ServiceLogger) (string, error) {
+func (h *Handler) getAuthenticatedUserID(ctx context.Context, r *http.Request) (string, error) {
 	user, err := token.GetUserInfo(r)
 	if err != nil {
-		log.Error("Failed to get user info from token", err)
+		h.log.Error("Failed to get user info from token", err)
 		return "", fmt.Errorf("Unauthorized")
 	}
 
 	// the goauth package stores email in Name field for local provider
 	userEmail := user.Name
 	if userEmail == "" {
-		log.Error("No email found in user token", nil)
+		h.log.Error("No email found in user token", nil)
 		return "", fmt.Errorf("Unauthorized")
 	}
 
-	dbUser, err := database.GetUserByEmail(ctx, userEmail)
+	dbUser, err := h.database.GetUserByEmail(ctx, userEmail)
 	if err != nil {
-		log.Error("Failed to get user from database", err)
+		h.log.Error("Failed to get user from database", err)
 		return "", fmt.Errorf("Internal server error")
 	}
 	if dbUser == nil {
-		log.Error("User not found in database", nil)
+		h.log.Error("User not found in database", nil)
 		return "", fmt.Errorf("User not found")
 	}
 
@@ -683,21 +681,21 @@ func createActivityResult(activity *models.Activity) ActivityResult {
 	}
 }
 
-func HandleGetActivities(database db.Database, log logger.ServiceLogger) http.HandlerFunc {
+func (h *Handler) HandleGetActivities() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := context.Background()
 
 		// Get authenticated user ID using the same helper function
-		userID, err := getAuthenticatedUserID(ctx, r, database, log)
+		userID, err := h.getAuthenticatedUserID(ctx, r)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusUnauthorized)
 			return
 		}
 
 		// Get user's activities from database
-		activities, err := database.GetActivitiesByUserID(ctx, userID)
+		activities, err := h.database.GetActivitiesByUserID(ctx, userID)
 		if err != nil {
-			log.Error("Failed to get activities from database", err)
+			h.log.Error("Failed to get activities from database", err)
 			http.Error(w, "Failed to retrieve activities", http.StatusInternalServerError)
 			return
 		}

--- a/backend/internal/handlers/activities.go
+++ b/backend/internal/handlers/activities.go
@@ -346,7 +346,7 @@ func processGPSData(samples []Sample) (string, float64, Bounds) {
 
 // Helper function to get elevation data and heights from Valhalla, returns calculated
 // elevation change and array of elevation heights
-func getElevationDataAndHeights(ctx context.Context, valhallaClient *valhalla.Client, polyline string, log logger.ServiceLogger) (*valhalla.ElevationChange, []float64) {
+func getElevationDataAndHeights(ctx context.Context, valhallaClient *valhalla.Client, polyline string, log *logger.ServiceLogger) (*valhalla.ElevationChange, []float64) {
 	heightReq := valhalla.HeightRequest{
 		Range:           false, // range off
 		EncodedPolyline: polyline,
@@ -621,7 +621,7 @@ func buildActivityModel(req CreateActivityRequest, userID string, polyline strin
 }
 
 // Helper function to create and store FIT file
-func createAndStoreFITFile(ctx context.Context, activity *models.Activity, samples []Sample, objectStore store.ObjectStore, log logger.ServiceLogger) error {
+func createAndStoreFITFile(ctx context.Context, activity *models.Activity, samples []Sample, objectStore store.ObjectStore, log *logger.ServiceLogger) error {
 	objectKey := fmt.Sprintf("activities/%s/%s.fit", activity.UserID, activity.ID.String())
 
 	if err := createFITFile(ctx, activity, samples, objectStore, log); err != nil {
@@ -718,7 +718,7 @@ func (h *Handler) HandleGetActivities() http.HandlerFunc {
 }
 
 // createFITFile generates a FIT file from activity data and saves it to object store
-func createFITFile(ctx context.Context, activity *models.Activity, samples []Sample, objectStore store.ObjectStore, log logger.ServiceLogger) error {
+func createFITFile(ctx context.Context, activity *models.Activity, samples []Sample, objectStore store.ObjectStore, log *logger.ServiceLogger) error {
 	// Create FIT activity file using muktihari/fit library
 	fitActivity := filedef.NewActivity()
 

--- a/backend/internal/handlers/auth.go
+++ b/backend/internal/handlers/auth.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/anish-chanda/cadent/backend/internal/db"
-	"github.com/anish-chanda/cadent/backend/internal/logger"
 	"github.com/anish-chanda/cadent/backend/internal/models"
 	"github.com/google/uuid"
 	"golang.org/x/crypto/argon2"
@@ -39,8 +38,7 @@ type SignupResponse struct {
 	Message string `json:"message"`
 }
 
-// SignupHandler handles user registration
-func SignupHandler(database db.Database, log logger.ServiceLogger) http.HandlerFunc {
+func (h *Handler) SignupHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -49,7 +47,7 @@ func SignupHandler(database db.Database, log logger.ServiceLogger) http.HandlerF
 
 		var req SignupRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			log.Error("Failed to decode signup request", err)
+			h.log.Error("Failed to decode signup request", err)
 			response := SignupResponse{
 				Success: false,
 				Message: "Invalid request format",
@@ -100,9 +98,9 @@ func SignupHandler(database db.Database, log logger.ServiceLogger) http.HandlerF
 		}
 
 		// Check if user already exists
-		existingUser, err := database.GetUserByEmail(r.Context(), email)
+		existingUser, err := h.database.GetUserByEmail(r.Context(), email)
 		if err != nil {
-			log.Error("Failed to check existing user", err)
+			h.log.Error("Failed to check existing user", err)
 			response := SignupResponse{
 				Success: false,
 				Message: "Internal server error",
@@ -125,9 +123,9 @@ func SignupHandler(database db.Database, log logger.ServiceLogger) http.HandlerF
 		}
 
 		// Create new user
-		user, err := createUser(database, email, password, name)
+		user, err := createUser(h.database, email, password, name)
 		if err != nil {
-			log.Error("Failed to create user", err)
+			h.log.Error("Failed to create user", err)
 			response := SignupResponse{
 				Success: false,
 				Message: "Failed to create user account",
@@ -138,7 +136,7 @@ func SignupHandler(database db.Database, log logger.ServiceLogger) http.HandlerF
 			return
 		}
 
-		log.Info(fmt.Sprintf("User created successfully: %s", email))
+		h.log.Info(fmt.Sprintf("User created successfully: %s", email))
 
 		response := SignupResponse{
 			Success: true,
@@ -207,13 +205,12 @@ func verifyPassword(password, encoded string) (bool, error) {
 	return false, nil
 }
 
-// HandleLogin handles local authentication by checking email and password
-func HandleLogin(database db.Database, email, password string) (bool, error) {
+func (h *Handler) HandleLogin(email, password string) (bool, error) {
 	// Normalize email
 	email = strings.TrimSpace(strings.ToLower(email))
 
 	// Get user by email
-	user, err := database.GetUserByEmail(context.TODO(), email)
+	user, err := h.database.GetUserByEmail(context.TODO(), email)
 	if err != nil {
 		return false, fmt.Errorf("failed to get user: %w", err)
 	}

--- a/backend/internal/handlers/auth_test.go
+++ b/backend/internal/handlers/auth_test.go
@@ -368,8 +368,9 @@ func TestHandleLogin(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			db := newMockDatabase()
 			tt.setupDB(db)
+			h := NewHandler(db, nil, nil, &logger.ServiceLogger{})
 
-			ok, err := HandleLogin(db, tt.email, tt.password)
+			ok, err := h.HandleLogin(tt.email, tt.password)
 
 			if ok != tt.expectOk {
 				t.Errorf("Expected ok=%v, got ok=%v", tt.expectOk, ok)
@@ -746,8 +747,9 @@ func TestSignupHandler(t *testing.T) {
 				ServiceName: "test",
 			})
 
-			// Create handler
-			handler := SignupHandler(mockDB, *mockLog)
+			// Create handler service and route handler
+			h := NewHandler(mockDB, nil, nil, mockLog)
+			handler := h.SignupHandler()
 
 			// Create request
 			req := httptest.NewRequest(tt.method, "/signup", strings.NewReader(tt.requestBody))

--- a/backend/internal/handlers/handler.go
+++ b/backend/internal/handlers/handler.go
@@ -12,11 +12,11 @@ type Handler struct {
 	database       db.Database
 	valhallaClient *valhalla.Client
 	objectStore    store.ObjectStore
-	log            logger.ServiceLogger
+	log            *logger.ServiceLogger
 }
 
 // NewHandler creates a handler set with shared dependencies.
-func NewHandler(database db.Database, valhallaClient *valhalla.Client, objectStore store.ObjectStore, log logger.ServiceLogger) *Handler {
+func NewHandler(database db.Database, valhallaClient *valhalla.Client, objectStore store.ObjectStore, log *logger.ServiceLogger) *Handler {
 	return &Handler{
 		database:       database,
 		valhallaClient: valhallaClient,

--- a/backend/internal/handlers/handler.go
+++ b/backend/internal/handlers/handler.go
@@ -1,0 +1,26 @@
+package handlers
+
+import (
+	"github.com/anish-chanda/cadent/backend/internal/db"
+	"github.com/anish-chanda/cadent/backend/internal/logger"
+	"github.com/anish-chanda/cadent/backend/internal/store"
+	"github.com/anish-chanda/cadent/backend/internal/valhalla"
+)
+
+// Handler groups shared dependencies used by HTTP and auth handlers.
+type Handler struct {
+	database       db.Database
+	valhallaClient *valhalla.Client
+	objectStore    store.ObjectStore
+	log            logger.ServiceLogger
+}
+
+// NewHandler creates a handler set with shared dependencies.
+func NewHandler(database db.Database, valhallaClient *valhalla.Client, objectStore store.ObjectStore, log logger.ServiceLogger) *Handler {
+	return &Handler{
+		database:       database,
+		valhallaClient: valhallaClient,
+		objectStore:    objectStore,
+		log:            log,
+	}
+}

--- a/backend/internal/handlers/planned_activity.go
+++ b/backend/internal/handlers/planned_activity.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/anish-chanda/cadent/backend/internal/db"
-	"github.com/anish-chanda/cadent/backend/internal/logger"
 	"github.com/anish-chanda/cadent/backend/internal/models"
 )
 
@@ -26,12 +24,12 @@ type CreatePlannedActivityRequest struct {
 	TargetPowerWatt                  *int     `json:"targetPowerWatt"`
 }
 
-func HandleCreatePlannedActivity(database db.Database, log logger.ServiceLogger) http.HandlerFunc {
+func (h *Handler) HandleCreatePlannedActivity() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
 		// 1. Auth Check
-		userID, err := getAuthenticatedUserID(ctx, r, database, log)
+		userID, err := h.getAuthenticatedUserID(ctx, r)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusUnauthorized)
 			return
@@ -40,7 +38,7 @@ func HandleCreatePlannedActivity(database db.Database, log logger.ServiceLogger)
 		// 2. Decode the JSON Body
 		var req CreatePlannedActivityRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			log.Error("Failed to decode plan request", err)
+			h.log.Error("Failed to decode plan request", err)
 			sendError(w, http.StatusBadRequest, "Invalid JSON format")
 			return
 		}
@@ -56,7 +54,7 @@ func HandleCreatePlannedActivity(database db.Database, log logger.ServiceLogger)
 		}
 		// Validate activity_type enum database insertion to return 400
 		if req.ActivityType != string(models.ActivityTypeRun) && req.ActivityType != string(models.ActivityTypeRoadBike) {
-			log.Error("Invalid activity type", fmt.Errorf("unsupported activity_type: %s", req.ActivityType))
+			h.log.Error("Invalid activity type", fmt.Errorf("unsupported activity_type: %s", req.ActivityType))
 			sendError(w, http.StatusBadRequest, fmt.Sprintf("Invalid activity_type: %s. Supported types: run, road_bike", req.ActivityType))
 			return
 		}
@@ -75,9 +73,9 @@ func HandleCreatePlannedActivity(database db.Database, log logger.ServiceLogger)
 			TargetPowerWatt:       req.TargetPowerWatt,
 		}
 
-		saved, err := database.CreatePlannedActivity(ctx, plan)
+		saved, err := h.database.CreatePlannedActivity(ctx, plan)
 		if err != nil {
-			log.Error("Database failed", err)
+			h.log.Error("Database failed", err)
 			sendError(w, http.StatusInternalServerError, "Failed to save to database")
 			return
 		}

--- a/backend/internal/handlers/streams.go
+++ b/backend/internal/handlers/streams.go
@@ -42,22 +42,21 @@ type StreamsResponse struct {
 	Streams           []StreamData         `json:"streams"`
 }
 
-// HandleGetActivityStreams handles GET /v1/activities/{id}/streams
-func HandleGetActivityStreams(database db.Database, log logger.ServiceLogger) http.HandlerFunc {
+func (h *Handler) HandleGetActivityStreams() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := context.Background()
 
 		// Get activity ID from URL path
 		activityID := chi.URLParam(r, "id")
 		if activityID == "" {
-			log.Error("Missing activity ID in URL path", nil)
+			h.log.Error("Missing activity ID in URL path", nil)
 			http.Error(w, "Activity ID is required", http.StatusBadRequest)
 			return
 		}
 
 		// Validate activity ID format
 		if _, err := uuid.Parse(activityID); err != nil {
-			log.Error("Invalid activity ID format", err)
+			h.log.Error("Invalid activity ID format", err)
 			http.Error(w, "Invalid activity ID format", http.StatusBadRequest)
 			return
 		}
@@ -65,39 +64,39 @@ func HandleGetActivityStreams(database db.Database, log logger.ServiceLogger) ht
 		// Parse query parameters
 		req, err := parseStreamRequest(r)
 		if err != nil {
-			log.Error("Failed to parse stream request", err)
+			h.log.Error("Failed to parse stream request", err)
 			http.Error(w, fmt.Sprintf("Invalid request parameters: %v", err), http.StatusBadRequest)
 			return
 		}
 
 		// Get authenticated user ID
-		userID, err := getAuthenticatedUserID(ctx, r, database, log)
+		userID, err := h.getAuthenticatedUserID(ctx, r)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusUnauthorized)
 			return
 		}
 
 		// Get activity to check ownership
-		activity, err := database.GetActivityByID(ctx, activityID)
+		activity, err := h.database.GetActivityByID(ctx, activityID)
 		if err != nil {
-			log.Error("Failed to get activity from database", err)
+			h.log.Error("Failed to get activity from database", err)
 			http.Error(w, "Internal server error", http.StatusInternalServerError)
 			return
 		}
 		if activity == nil {
-			log.Info(fmt.Sprintf("Activity not found: %s", activityID))
+			h.log.Info(fmt.Sprintf("Activity not found: %s", activityID))
 			http.Error(w, "Activity not found", http.StatusNotFound)
 			return
 		}
 
 		// Check if the authenticated user owns this activity
 		if activity.UserID != userID {
-			log.Debug(fmt.Sprintf("User %s attempted to access activity %s owned by %s", userID, activityID, activity.UserID))
+			h.log.Debug(fmt.Sprintf("User %s attempted to access activity %s owned by %s", userID, activityID, activity.UserID))
 			http.Error(w, "Activity not found", http.StatusNotFound) // Return 404 instead of 403
 			return
 		}
 
-		log.Debug(fmt.Sprintf("User %s requesting streams for activity %s with LOD %s and types %v", userID, activityID, req.LOD, req.Types))
+		h.log.Debug(fmt.Sprintf("User %s requesting streams for activity %s with LOD %s and types %v", userID, activityID, req.LOD, req.Types))
 
 		// Get activity streams from database based on LOD
 		var responseStreams []StreamData
@@ -106,7 +105,7 @@ func HandleGetActivityStreams(database db.Database, log logger.ServiceLogger) ht
 		switch req.LOD {
 		case models.StreamLODMedium:
 			// Get medium LOD from database
-			responseStreams, numPoints, originalNumPoints, err = getMediumLODStreams(ctx, database, activityID, req.Types, log)
+			responseStreams, numPoints, originalNumPoints, err = getMediumLODStreams(ctx, h.database, activityID, req.Types, h.log)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
@@ -114,7 +113,7 @@ func HandleGetActivityStreams(database db.Database, log logger.ServiceLogger) ht
 
 		case models.StreamLODLow:
 			// Calculate low LOD on the fly from medium LOD
-			responseStreams, numPoints, originalNumPoints, err = getLowLODStreams(ctx, database, activityID, req.Types, log)
+			responseStreams, numPoints, originalNumPoints, err = getLowLODStreams(ctx, h.database, activityID, req.Types, h.log)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
@@ -122,7 +121,7 @@ func HandleGetActivityStreams(database db.Database, log logger.ServiceLogger) ht
 
 		case models.StreamLODFull:
 			// TODO: Get full resolution from FIT file in object storage
-			log.Error("Full LOD streams not yet implemented - requires FIT file parsing", nil)
+			h.log.Error("Full LOD streams not yet implemented - requires FIT file parsing", nil)
 			http.Error(w, "Full resolution streams not available", http.StatusNotImplemented)
 			return
 
@@ -132,7 +131,7 @@ func HandleGetActivityStreams(database db.Database, log logger.ServiceLogger) ht
 		}
 
 		if len(responseStreams) == 0 {
-			log.Info(fmt.Sprintf("No stream data found for activity %s with LOD %s", activityID, req.LOD))
+			h.log.Info(fmt.Sprintf("No stream data found for activity %s with LOD %s", activityID, req.LOD))
 			http.Error(w, "Stream data not found", http.StatusNotFound)
 			return
 		}
@@ -149,12 +148,12 @@ func HandleGetActivityStreams(database db.Database, log logger.ServiceLogger) ht
 
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(response); err != nil {
-			log.Error("Failed to encode response", err)
+			h.log.Error("Failed to encode response", err)
 			http.Error(w, "Internal server error", http.StatusInternalServerError)
 			return
 		}
 
-		log.Debug(fmt.Sprintf("Successfully returned %d stream types for activity %s with LOD %s", len(responseStreams), activityID, req.LOD))
+		h.log.Debug(fmt.Sprintf("Successfully returned %d stream types for activity %s with LOD %s", len(responseStreams), activityID, req.LOD))
 	}
 }
 

--- a/backend/internal/handlers/streams.go
+++ b/backend/internal/handlers/streams.go
@@ -158,7 +158,7 @@ func (h *Handler) HandleGetActivityStreams() http.HandlerFunc {
 }
 
 // getMediumLODStreams retrieves medium LOD streams from database
-func getMediumLODStreams(ctx context.Context, database db.Database, activityID string, requestedTypes []models.StreamType, log logger.ServiceLogger) ([]StreamData, int, int, error) {
+func getMediumLODStreams(ctx context.Context, database db.Database, activityID string, requestedTypes []models.StreamType, log *logger.ServiceLogger) ([]StreamData, int, int, error) {
 	activityStreams, err := database.GetActivityStreams(ctx, activityID, models.StreamLODMedium)
 	if err != nil {
 		log.Error("Failed to get activity streams from database", err)
@@ -214,7 +214,7 @@ func getMediumLODStreams(ctx context.Context, database db.Database, activityID s
 }
 
 // getLowLODStreams calculates low LOD streams by further decimating medium LOD data
-func getLowLODStreams(ctx context.Context, database db.Database, activityID string, requestedTypes []models.StreamType, log logger.ServiceLogger) ([]StreamData, int, int, error) {
+func getLowLODStreams(ctx context.Context, database db.Database, activityID string, requestedTypes []models.StreamType, log *logger.ServiceLogger) ([]StreamData, int, int, error) {
 	// First get medium LOD streams
 	mediumStreams, _, originalNumPoints, err := getMediumLODStreams(ctx, database, activityID, requestedTypes, log)
 	if err != nil {

--- a/backend/internal/handlers/streams_test.go
+++ b/backend/internal/handlers/streams_test.go
@@ -319,7 +319,7 @@ func TestGetMediumLODStreams(t *testing.T) {
 	requestedTypes := []models.StreamType{models.StreamTypeTime, models.StreamTypeDistance}
 
 	resultStreams, numPoints, originalNumPoints, err := getMediumLODStreams(
-		context.Background(), mockDB, activityID, requestedTypes, *testLogger)
+		context.Background(), mockDB, activityID, requestedTypes, testLogger)
 
 	if err != nil {
 		t.Errorf("getMediumLODStreams() error = %v, want nil", err)
@@ -354,7 +354,7 @@ func TestGetMediumLODStreams_NoStreamsFound(t *testing.T) {
 	requestedTypes := []models.StreamType{models.StreamTypeTime}
 
 	_, _, _, err := getMediumLODStreams(
-		context.Background(), mockDB, activityID, requestedTypes, *testLogger)
+		context.Background(), mockDB, activityID, requestedTypes, testLogger)
 
 	if err == nil {
 		t.Error("getMediumLODStreams() should return error when no streams found")
@@ -851,14 +851,14 @@ func TestHandleGetActivityStreams(t *testing.T) {
 
 				switch req.LOD {
 				case models.StreamLODMedium:
-					responseStreams, numPoints, originalNumPoints, err = getMediumLODStreams(ctx, mockDB, activityID, req.Types, *mockLog)
+					responseStreams, numPoints, originalNumPoints, err = getMediumLODStreams(ctx, mockDB, activityID, req.Types, mockLog)
 					if err != nil {
 						http.Error(w, "Internal server error", http.StatusInternalServerError)
 						return
 					}
 
 				case models.StreamLODLow:
-					responseStreams, numPoints, originalNumPoints, err = getLowLODStreams(ctx, mockDB, activityID, req.Types, *mockLog)
+					responseStreams, numPoints, originalNumPoints, err = getLowLODStreams(ctx, mockDB, activityID, req.Types, mockLog)
 					if err != nil {
 						http.Error(w, "Internal server error", http.StatusInternalServerError)
 						return

--- a/backend/internal/handlers/uploads.go
+++ b/backend/internal/handlers/uploads.go
@@ -11,10 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/anish-chanda/cadent/backend/internal/db"
-	"github.com/anish-chanda/cadent/backend/internal/logger"
 	"github.com/anish-chanda/cadent/backend/internal/models"
-	"github.com/anish-chanda/cadent/backend/internal/store"
 	"github.com/anish-chanda/cadent/backend/internal/valhalla"
 	"github.com/google/uuid"
 	"github.com/muktihari/fit/decoder"
@@ -38,9 +35,7 @@ type UploadResponse struct {
 	ID string `json:"id"`
 }
 
-// HandleActivityUpload supports uploading/importing activites from GPX and FIT files.
-// Parameters- enrich (true) to add elevation data, title and description to override file metadata
-func HandleActivityUpload(database db.Database, valhallaClient *valhalla.Client, objectStore store.ObjectStore, log logger.ServiceLogger) http.HandlerFunc {
+func (h *Handler) HandleActivityUpload() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
@@ -49,7 +44,7 @@ func HandleActivityUpload(database db.Database, valhallaClient *valhalla.Client,
 
 		// Parse multipart form with size limit
 		if err := r.ParseMultipartForm(maxUploadSize); err != nil {
-			log.Error("Failed to parse multipart form", err)
+			h.log.Error("Failed to parse multipart form", err)
 			// Check if it's a size error or content-type error
 			if strings.Contains(err.Error(), "Content-Type") || strings.Contains(err.Error(), "multipart") {
 				http.Error(w, "Request must use multipart/form-data Content-Type", http.StatusBadRequest)
@@ -62,7 +57,7 @@ func HandleActivityUpload(database db.Database, valhallaClient *valhalla.Client,
 		// Get the file from form data
 		file, header, err := r.FormFile("file")
 		if err != nil {
-			log.Error("Failed to get file from form", err)
+			h.log.Error("Failed to get file from form", err)
 			http.Error(w, "Missing or invalid 'file' field in form data", http.StatusBadRequest)
 			return
 		}
@@ -85,7 +80,7 @@ func HandleActivityUpload(database db.Database, valhallaClient *valhalla.Client,
 		descriptionOverride := r.FormValue("description")
 
 		// Get authenticated user ID
-		userID, err := getAuthenticatedUserID(ctx, r, database, log)
+		userID, err := h.getAuthenticatedUserID(ctx, r)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusUnauthorized)
 			return
@@ -94,7 +89,7 @@ func HandleActivityUpload(database db.Database, valhallaClient *valhalla.Client,
 		// Read file content
 		fileContent, err := io.ReadAll(file)
 		if err != nil {
-			log.Error("Failed to read file content", err)
+			h.log.Error("Failed to read file content", err)
 			http.Error(w, "Failed to read uploaded file", http.StatusInternalServerError)
 			return
 		}
@@ -111,7 +106,7 @@ func HandleActivityUpload(database db.Database, valhallaClient *valhalla.Client,
 		}
 
 		if err != nil {
-			log.Error(fmt.Sprintf("Failed to process %s file", strings.ToUpper(ext[1:])), err)
+			h.log.Error(fmt.Sprintf("Failed to process %s file", strings.ToUpper(ext[1:])), err)
 			http.Error(w, fmt.Sprintf("Failed to process %s file: %v", strings.ToUpper(ext[1:]), err), http.StatusBadRequest)
 			return
 		}
@@ -143,7 +138,7 @@ func HandleActivityUpload(database db.Database, valhallaClient *valhalla.Client,
 
 		// Validate activity type
 		if metadata.ActivityType != models.ActivityTypeRun && metadata.ActivityType != models.ActivityTypeRoadBike {
-			log.Error("Invalid activity type", fmt.Errorf("unsupported activity_type: %s", metadata.ActivityType))
+			h.log.Error("Invalid activity type", fmt.Errorf("unsupported activity_type: %s", metadata.ActivityType))
 			http.Error(w, fmt.Sprintf("Invalid activity_type: %s. Supported types: run, road_bike", metadata.ActivityType), http.StatusBadRequest)
 			return
 		}
@@ -156,13 +151,13 @@ func HandleActivityUpload(database db.Database, valhallaClient *valhalla.Client,
 		var elevationHeights []float64
 
 		if shouldEnrich && !hasElevation {
-			elevationData, elevationHeights = getElevationDataAndHeights(ctx, valhallaClient, polyline, log)
+			elevationData, elevationHeights = getElevationDataAndHeights(ctx, h.valhallaClient, polyline, h.log)
 
 			// For GPX uploads we can write the elevation back into the file so the stored copy
 			// reflects the enriched data.
 			if ext == ".gpx" && elevationHeights != nil {
 				if updated, enrichErr := enrichGPXWithElevation(fileContent, elevationHeights); enrichErr != nil {
-					log.Error("Failed to enrich GPX with elevation data, storing original", enrichErr)
+					h.log.Error("Failed to enrich GPX with elevation data, storing original", enrichErr)
 				} else {
 					fileContent = updated
 				}
@@ -202,15 +197,15 @@ func HandleActivityUpload(database db.Database, valhallaClient *valhalla.Client,
 		}
 		activity := buildActivityModel(uploadReq, userID, polyline, totalDistance, bounds, elevationData, elapsedSeconds, avgSpeedMs)
 		if ext == ".fit" && elevationHeights != nil && enrichParam == "true" {
-			if err := createFITFile(ctx, activity, samples, objectStore, log); err != nil {
-				log.Error("Failed to regenerate enriched FIT file", err)
+			if err := createFITFile(ctx, activity, samples, h.objectStore, h.log); err != nil {
+				h.log.Error("Failed to regenerate enriched FIT file", err)
 			}
 		}
 		// Store the file to disk in original format (GPX or FIT), including elevation if enrichment was applied
 		originalFileKey := fmt.Sprintf("activities/%s/%s%s", userID, activity.ID.String(), ext)
 		fileReader := bytes.NewReader(fileContent)
-		if err := objectStore.PutObject(ctx, originalFileKey, fileReader, int64(len(fileContent))); err != nil {
-			log.Error("Failed to store uploaded file", err)
+		if err := h.objectStore.PutObject(ctx, originalFileKey, fileReader, int64(len(fileContent))); err != nil {
+			h.log.Error("Failed to store uploaded file", err)
 			http.Error(w, "Failed to store uploaded file", http.StatusInternalServerError)
 			return
 		}
@@ -221,7 +216,7 @@ func HandleActivityUpload(database db.Database, valhallaClient *valhalla.Client,
 
 		// Validate stream alignment
 		if err := validateStreamAlignment(fullStream, len(samples)); err != nil {
-			log.Error("Stream alignment validation failed", err)
+			h.log.Error("Stream alignment validation failed", err)
 			http.Error(w, "Internal stream processing error", http.StatusInternalServerError)
 			return
 		}
@@ -232,30 +227,30 @@ func HandleActivityUpload(database db.Database, valhallaClient *valhalla.Client,
 		// Create compressed medium LOD streams
 		activityStreams, err := createCompressedStreams(activity.ID, keepIndices, fullStream)
 		if err != nil {
-			log.Error("Failed to create compressed streams", err)
+			h.log.Error("Failed to create compressed streams", err)
 			http.Error(w, "Failed to process stream data", http.StatusInternalServerError)
 			return
 		}
 
 		// Save activity to database
-		if err := database.CreateActivity(ctx, activity); err != nil {
-			log.Error("Failed to save activity to database", err)
+		if err := h.database.CreateActivity(ctx, activity); err != nil {
+			h.log.Error("Failed to save activity to database", err)
 			http.Error(w, "Failed to save activity", http.StatusInternalServerError)
 			return
 		}
 
 		// Save activity streams to database
 		if len(activityStreams) > 0 {
-			if err := database.CreateActivityStreams(ctx, activityStreams); err != nil {
-				log.Error("Failed to save activity streams to database", err)
+			if err := h.database.CreateActivityStreams(ctx, activityStreams); err != nil {
+				h.log.Error("Failed to save activity streams to database", err)
 				// Log error but don't fail the request since main activity was saved
-				log.Info("Activity created successfully but streams failed to save")
+				h.log.Info("Activity created successfully but streams failed to save")
 			} else {
-				log.Debug(fmt.Sprintf("Successfully saved %d streams for activity: %s", len(activityStreams), activity.ID.String()))
+				h.log.Debug(fmt.Sprintf("Successfully saved %d streams for activity: %s", len(activityStreams), activity.ID.String()))
 			}
 		}
 
-		log.Info(fmt.Sprintf("Successfully processed %s file upload for user %s, activity: %s", strings.ToUpper(ext[1:]), userID, activity.ID.String()))
+		h.log.Info(fmt.Sprintf("Successfully processed %s file upload for user %s, activity: %s", strings.ToUpper(ext[1:]), userID, activity.ID.String()))
 
 		// Return response with activity ID
 		response := UploadResponse{

--- a/backend/internal/handlers/user.go
+++ b/backend/internal/handlers/user.go
@@ -7,8 +7,6 @@ import (
 	"net/mail"
 	"strings"
 
-	"github.com/anish-chanda/cadent/backend/internal/db"
-	"github.com/anish-chanda/cadent/backend/internal/logger"
 	"github.com/go-pkgz/auth/v2/token"
 )
 
@@ -25,15 +23,14 @@ type UserUpdateRequest struct {
 	Email *string `json:"email"`
 }
 
-// HandleGetUser handles GET /v1/user - returns user profile information
-func HandleGetUser(database db.Database, log logger.ServiceLogger) http.HandlerFunc {
+func (h *Handler) HandleGetUser() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := context.Background()
 
 		// Get authenticated user information
 		user, err := token.GetUserInfo(r)
 		if err != nil {
-			log.Error("Failed to get user info from token", err)
+			h.log.Error("Failed to get user info from token", err)
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}
@@ -41,20 +38,20 @@ func HandleGetUser(database db.Database, log logger.ServiceLogger) http.HandlerF
 		// Extract email from token
 		userEmail := user.Name
 		if userEmail == "" {
-			log.Error("No email found in user token", nil)
+			h.log.Error("No email found in user token", nil)
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}
 
 		// Look up database user by email
-		dbUser, err := database.GetUserByEmail(ctx, userEmail)
+		dbUser, err := h.database.GetUserByEmail(ctx, userEmail)
 		if err != nil {
-			log.Error("Failed to get user from database", err)
+			h.log.Error("Failed to get user from database", err)
 			http.Error(w, "Internal server error", http.StatusInternalServerError)
 			return
 		}
 		if dbUser == nil {
-			log.Error("User not found in database", nil)
+			h.log.Error("User not found in database", nil)
 			http.Error(w, "User not found", http.StatusNotFound)
 			return
 		}
@@ -71,15 +68,14 @@ func HandleGetUser(database db.Database, log logger.ServiceLogger) http.HandlerF
 	}
 }
 
-// HandleUpdateUser handles PATCH /v1/user - updates user profile information
-func HandleUpdateUser(database db.Database, log logger.ServiceLogger) http.HandlerFunc {
+func (h *Handler) HandleUpdateUser() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := context.Background()
 
 		// Get authenticated user information
 		user, err := token.GetUserInfo(r)
 		if err != nil {
-			log.Error("Failed to get user info from token", err)
+			h.log.Error("Failed to get user info from token", err)
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}
@@ -87,20 +83,20 @@ func HandleUpdateUser(database db.Database, log logger.ServiceLogger) http.Handl
 		// Extract email from token
 		userEmail := user.Name
 		if userEmail == "" {
-			log.Error("No email found in user token", nil)
+			h.log.Error("No email found in user token", nil)
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}
 
 		// Look up database user by email
-		dbUser, err := database.GetUserByEmail(ctx, userEmail)
+		dbUser, err := h.database.GetUserByEmail(ctx, userEmail)
 		if err != nil {
-			log.Error("Failed to get user from database", err)
+			h.log.Error("Failed to get user from database", err)
 			http.Error(w, "Internal server error", http.StatusInternalServerError)
 			return
 		}
 		if dbUser == nil {
-			log.Error("User not found in database", nil)
+			h.log.Error("User not found in database", nil)
 			http.Error(w, "User not found", http.StatusNotFound)
 			return
 		}
@@ -108,7 +104,7 @@ func HandleUpdateUser(database db.Database, log logger.ServiceLogger) http.Handl
 		// Parse request body
 		var updateReq UserUpdateRequest
 		if err := json.NewDecoder(r.Body).Decode(&updateReq); err != nil {
-			log.Error("Failed to decode request body", err)
+			h.log.Error("Failed to decode request body", err)
 			http.Error(w, "Invalid request body", http.StatusBadRequest)
 			return
 		}
@@ -146,17 +142,17 @@ func HandleUpdateUser(database db.Database, log logger.ServiceLogger) http.Handl
 		}
 
 		// Update user in database
-		err = database.UpdateUser(ctx, dbUser.ID, updates)
+		err = h.database.UpdateUser(ctx, dbUser.ID, updates)
 		if err != nil {
-			log.Error("Failed to update user in database", err)
+			h.log.Error("Failed to update user in database", err)
 			http.Error(w, "Failed to update user", http.StatusInternalServerError)
 			return
 		}
 
 		// Get updated user data, might have changed by other instances
-		updatedUser, err := database.GetUserByID(ctx, dbUser.ID)
+		updatedUser, err := h.database.GetUserByID(ctx, dbUser.ID)
 		if err != nil {
-			log.Error("Failed to get updated user", err)
+			h.log.Error("Failed to get updated user", err)
 			http.Error(w, "Internal server error", http.StatusInternalServerError)
 			return
 		}

--- a/backend/main.go
+++ b/backend/main.go
@@ -109,9 +109,10 @@ func main() {
 
 	// Create auth service with providers
 	authService := authpkg.NewService(authOptions)
+	apiHandler := handlers.NewHandler(database, valhallaClient, objectStore, *log)
 
 	authService.AddDirectProvider("local", provider.CredCheckerFunc(func(user, password string) (ok bool, err error) {
-		return handlers.HandleLogin(database, user, password)
+		return apiHandler.HandleLogin(user, password)
 	}))
 
 	// Create router
@@ -146,7 +147,7 @@ func main() {
 	router.Mount("/api/avatar", avatarHandler)
 
 	// Custom auth endpoints
-	router.Post("/api/signup", handlers.SignupHandler(database, *log))
+	router.Post("/api/signup", apiHandler.SignupHandler())
 
 	// Mount V1 API routes
 	router.Route("/api/v1", func(r chi.Router) {
@@ -157,15 +158,15 @@ func main() {
 			r.Use(authMiddleware.Auth)
 
 			// Activity endpoints
-			r.Post("/activities", handlers.HandleCreateActivity(database, valhallaClient, objectStore, *log))
-			r.Get("/activities", handlers.HandleGetActivities(database, *log))
-			r.Get("/activities/{id}/streams", handlers.HandleGetActivityStreams(database, *log))
-			r.Post("/activities/plan", handlers.HandleCreatePlannedActivity(database, *log))
-			r.Post("/activities/upload", handlers.HandleActivityUpload(database, valhallaClient, objectStore, *log))
+			r.Post("/activities", apiHandler.HandleCreateActivity())
+			r.Get("/activities", apiHandler.HandleGetActivities())
+			r.Get("/activities/{id}/streams", apiHandler.HandleGetActivityStreams())
+			r.Post("/activities/plan", apiHandler.HandleCreatePlannedActivity())
+			r.Post("/activities/upload", apiHandler.HandleActivityUpload())
 
 			// User endpoints
-			r.Get("/user", handlers.HandleGetUser(database, *log))
-			r.Patch("/user", handlers.HandleUpdateUser(database, *log))
+			r.Get("/user", apiHandler.HandleGetUser())
+			r.Patch("/user", apiHandler.HandleUpdateUser())
 		})
 	})
 

--- a/backend/main.go
+++ b/backend/main.go
@@ -109,7 +109,7 @@ func main() {
 
 	// Create auth service with providers
 	authService := authpkg.NewService(authOptions)
-	apiHandler := handlers.NewHandler(database, valhallaClient, objectStore, *log)
+	apiHandler := handlers.NewHandler(database, valhallaClient, objectStore, log)
 
 	authService.AddDirectProvider("local", provider.CredCheckerFunc(func(user, password string) (ok bool, err error) {
 		return apiHandler.HandleLogin(user, password)


### PR DESCRIPTION
I Refactored the handlers to use a single shared Handler struct replacing long repetitive argument lists. Also change the logger to be a pointer so the logger instance is shared (avoids copying). also updated tests to work with the new sigs