### PR TITLE
feat: add training plans screen and import functionality in app

### DIFF
--- a/app/lib/models/training_plan.dart
+++ b/app/lib/models/training_plan.dart
@@ -1,0 +1,270 @@
+enum TrainingPlanActivityTypeFilter { all, running, roadBiking }
+
+extension TrainingPlanActivityTypeFilterX on TrainingPlanActivityTypeFilter {
+  String get apiValue {
+    switch (this) {
+      case TrainingPlanActivityTypeFilter.all:
+        return 'all';
+      case TrainingPlanActivityTypeFilter.running:
+        return 'running';
+      case TrainingPlanActivityTypeFilter.roadBiking:
+        return 'road_biking';
+    }
+  }
+
+  String get label {
+    switch (this) {
+      case TrainingPlanActivityTypeFilter.all:
+        return 'All';
+      case TrainingPlanActivityTypeFilter.running:
+        return 'Running';
+      case TrainingPlanActivityTypeFilter.roadBiking:
+        return 'Road Biking';
+    }
+  }
+}
+
+class TrainingPlan {
+  final String id;
+  final String title;
+  final String? description;
+  final String? primaryActivityType;
+  final String difficulty;
+  final int durationWeeks;
+  final int recommendedWorkoutsPerWeek;
+  final bool isSystem;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  const TrainingPlan({
+    required this.id,
+    required this.title,
+    this.description,
+    this.primaryActivityType,
+    required this.difficulty,
+    required this.durationWeeks,
+    required this.recommendedWorkoutsPerWeek,
+    required this.isSystem,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  factory TrainingPlan.fromJson(Map<String, dynamic> json) {
+    return TrainingPlan(
+      id: json['id'] as String,
+      title: (json['title'] as String?)?.trim().isNotEmpty == true
+          ? json['title'] as String
+          : 'Untitled Plan',
+      description: json['description'] as String?,
+      primaryActivityType: json['primary_activity_type'] as String?,
+      difficulty: (json['difficulty'] as String?) ?? 'beginner',
+      durationWeeks: (json['duration_weeks'] as num?)?.toInt() ?? 0,
+      recommendedWorkoutsPerWeek:
+          (json['recommended_workouts_per_week'] as num?)?.toInt() ?? 1,
+      isSystem: json['is_system'] as bool? ?? false,
+      createdAt: DateTime.parse(json['created_at'] as String),
+      updatedAt: DateTime.parse(json['updated_at'] as String),
+    );
+  }
+}
+
+class TrainingPlanWorkout {
+  final String id;
+  final String trainingPlanId;
+  final int sequenceIndex;
+  final int templateDayOffset;
+  final String type;
+  final String title;
+  final String? description;
+  final double? plannedDistanceM;
+  final int? plannedDurationS;
+  final double? plannedElevationGainM;
+  final double? targetAvgSpeedMps;
+  final int? targetPowerWatt;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  const TrainingPlanWorkout({
+    required this.id,
+    required this.trainingPlanId,
+    required this.sequenceIndex,
+    required this.templateDayOffset,
+    required this.type,
+    required this.title,
+    this.description,
+    this.plannedDistanceM,
+    this.plannedDurationS,
+    this.plannedElevationGainM,
+    this.targetAvgSpeedMps,
+    this.targetPowerWatt,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  factory TrainingPlanWorkout.fromJson(Map<String, dynamic> json) {
+    return TrainingPlanWorkout(
+      id: json['id'] as String,
+      trainingPlanId: json['training_plan_id'] as String,
+      sequenceIndex: (json['sequence_index'] as num?)?.toInt() ?? 0,
+      templateDayOffset: (json['template_day_offset'] as num?)?.toInt() ?? 0,
+      type: (json['type'] as String?) ?? 'running',
+      title: (json['title'] as String?)?.trim().isNotEmpty == true
+          ? json['title'] as String
+          : 'Workout',
+      description: json['description'] as String?,
+      plannedDistanceM: (json['planned_distance_m'] as num?)?.toDouble(),
+      plannedDurationS: (json['planned_duration_s'] as num?)?.toInt(),
+      plannedElevationGainM: (json['planned_elevation_gain_m'] as num?)
+          ?.toDouble(),
+      targetAvgSpeedMps: (json['target_avg_speed_mps'] as num?)?.toDouble(),
+      targetPowerWatt: (json['target_power_watt'] as num?)?.toInt(),
+      createdAt: DateTime.parse(json['created_at'] as String),
+      updatedAt: DateTime.parse(json['updated_at'] as String),
+    );
+  }
+}
+
+class ImportTrainingPlanRequest {
+  final DateTime startDate;
+  final int selectedWorkoutsPerWeek;
+  final String title;
+  final String? description;
+
+  const ImportTrainingPlanRequest({
+    required this.startDate,
+    required this.selectedWorkoutsPerWeek,
+    required this.title,
+    this.description,
+  });
+
+  Map<String, dynamic> toJson() {
+    return {
+      'startDate': startDate.toUtc().toIso8601String(),
+      'selectedWorkoutsPerWeek': selectedWorkoutsPerWeek,
+      'title': title,
+      'description': description,
+    };
+  }
+}
+
+class ImportTrainingPlanDryRunRequest {
+  final DateTime startDate;
+  final int selectedWorkoutsPerWeek;
+  final String? title;
+  final String? description;
+
+  const ImportTrainingPlanDryRunRequest({
+    required this.startDate,
+    required this.selectedWorkoutsPerWeek,
+    this.title,
+    this.description,
+  });
+
+  Map<String, dynamic> toJson() {
+    return {
+      'startDate': startDate.toUtc().toIso8601String(),
+      'selectedWorkoutsPerWeek': selectedWorkoutsPerWeek,
+      if (title != null) 'title': title,
+      if (description != null) 'description': description,
+    };
+  }
+}
+
+class ImportTrainingPlanResponse {
+  final String userTrainingPlanId;
+  final int plannedActivitiesCreated;
+
+  const ImportTrainingPlanResponse({
+    required this.userTrainingPlanId,
+    required this.plannedActivitiesCreated,
+  });
+
+  factory ImportTrainingPlanResponse.fromJson(Map<String, dynamic> json) {
+    return ImportTrainingPlanResponse(
+      userTrainingPlanId: json['userTrainingPlanId'] as String,
+      plannedActivitiesCreated:
+          (json['plannedActivitiesCreated'] as num?)?.toInt() ?? 0,
+    );
+  }
+}
+
+class TrainingPlanPreviewActivity {
+  final String id;
+  final String title;
+  final String type;
+  final DateTime startTime;
+
+  const TrainingPlanPreviewActivity({
+    required this.id,
+    required this.title,
+    required this.type,
+    required this.startTime,
+  });
+
+  factory TrainingPlanPreviewActivity.fromJson(Map<String, dynamic> json) {
+    return TrainingPlanPreviewActivity(
+      id: json['id'] as String,
+      title: (json['title'] as String?) ?? 'Activity',
+      type: (json['type'] as String?) ?? 'running',
+      startTime: DateTime.parse(json['start_time'] as String),
+    );
+  }
+}
+
+class TrainingPlanPreviewPlannedActivity {
+  final String id;
+  final String title;
+  final String type;
+  final DateTime startTime;
+  final bool isDryRun;
+  final String? matchedActivityId;
+
+  const TrainingPlanPreviewPlannedActivity({
+    required this.id,
+    required this.title,
+    required this.type,
+    required this.startTime,
+    required this.isDryRun,
+    this.matchedActivityId,
+  });
+
+  factory TrainingPlanPreviewPlannedActivity.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return TrainingPlanPreviewPlannedActivity(
+      id: json['id'] as String,
+      title: (json['title'] as String?) ?? 'Planned Activity',
+      type: (json['type'] as String?) ?? 'running',
+      startTime: DateTime.parse(json['start_time'] as String),
+      isDryRun: json['is_dry_run'] as bool? ?? false,
+      matchedActivityId: json['matched_activity_id'] as String?,
+    );
+  }
+}
+
+class TrainingPlanPreviewResponse {
+  final List<TrainingPlanPreviewActivity> activities;
+  final List<TrainingPlanPreviewPlannedActivity> plannedActivities;
+
+  const TrainingPlanPreviewResponse({
+    required this.activities,
+    required this.plannedActivities,
+  });
+
+  factory TrainingPlanPreviewResponse.fromJson(Map<String, dynamic> json) {
+    final activitiesRaw = (json['activities'] as List<dynamic>? ?? []);
+    final plannedActivitiesRaw =
+        (json['planned_activities'] as List<dynamic>? ?? []);
+
+    return TrainingPlanPreviewResponse(
+      activities: activitiesRaw
+          .whereType<Map<String, dynamic>>()
+          .map(TrainingPlanPreviewActivity.fromJson)
+          .toList(),
+      plannedActivities: plannedActivitiesRaw
+          .whereType<Map<String, dynamic>>()
+          .map(TrainingPlanPreviewPlannedActivity.fromJson)
+          .toList(),
+    );
+  }
+}

--- a/app/lib/screens/training_plan_detail_screen.dart
+++ b/app/lib/screens/training_plan_detail_screen.dart
@@ -1,0 +1,401 @@
+import 'package:flutter/material.dart';
+
+import '../models/training_plan.dart';
+import '../services/training_plans_service.dart';
+import '../widgets/global/empty_state_widget.dart';
+import '../widgets/global/error_state_widget.dart';
+import '../widgets/global/loading_indicator.dart';
+import 'training_plan_import_sheet.dart';
+
+class TrainingPlanDetailScreen extends StatefulWidget {
+  final TrainingPlan plan;
+
+  const TrainingPlanDetailScreen({super.key, required this.plan});
+
+  @override
+  State<TrainingPlanDetailScreen> createState() =>
+      _TrainingPlanDetailScreenState();
+}
+
+class _TrainingPlanDetailScreenState extends State<TrainingPlanDetailScreen> {
+  bool _isLoading = true;
+  String? _errorMessage;
+  List<TrainingPlanWorkout> _workouts = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _loadWorkouts();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text(
+          'Training Plan',
+          style: TextStyle(fontWeight: FontWeight.bold),
+        ),
+      ),
+      body: _buildBody(context),
+    );
+  }
+
+  Widget _buildHeaderCard(BuildContext context) {
+    final plan = widget.plan;
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(14),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (plan.primaryActivityType != null)
+              Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 10,
+                  vertical: 4,
+                ),
+                decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.primaryContainer,
+                  borderRadius: BorderRadius.circular(999),
+                ),
+                child: Text(
+                  plan.primaryActivityType!.replaceAll('_', ' '),
+                  style: TextStyle(
+                    color: Theme.of(context).colorScheme.onPrimaryContainer,
+                    fontWeight: FontWeight.w600,
+                    fontSize: 12,
+                  ),
+                ),
+              ),
+            const SizedBox(height: 8),
+            Text(
+              plan.title,
+              style: Theme.of(
+                context,
+              ).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+            ),
+            if (plan.description != null && plan.description!.isNotEmpty) ...[
+              const SizedBox(height: 6),
+              Text(
+                plan.description!,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: Theme.of(context).colorScheme.outline,
+                ),
+              ),
+            ],
+            const SizedBox(height: 10),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              crossAxisAlignment: WrapCrossAlignment.center,
+              children: [
+                _InfoPill(
+                  icon: Icons.calendar_view_week,
+                  label: '${plan.durationWeeks} weeks',
+                ),
+                _InfoPill(
+                  icon: Icons.fitness_center,
+                  label: '${plan.recommendedWorkoutsPerWeek} per week',
+                ),
+                ElevatedButton.icon(
+                  onPressed: _openImportSheet,
+                  icon: const Icon(Icons.download),
+                  label: const Text('Import'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBody(BuildContext context) {
+    if (_isLoading) {
+      return const LoadingIndicator();
+    }
+
+    if (_errorMessage != null) {
+      return ErrorStateWidget(message: _errorMessage, onRetry: _loadWorkouts);
+    }
+
+    return RefreshIndicator(
+      onRefresh: () => _loadWorkouts(showLoading: false),
+      child: ListView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        padding: const EdgeInsets.fromLTRB(16, 8, 16, 90),
+        children: [
+          _buildHeaderCard(context),
+          const SizedBox(height: 8),
+          if (_workouts.isEmpty)
+            const Padding(
+              padding: EdgeInsets.only(top: 32),
+              child: EmptyStateWidget(
+                icon: Icons.event_busy,
+                title: 'No workouts in this plan',
+                message: 'This training plan has no workout templates yet.',
+              ),
+            )
+          else
+            ..._groupWorkoutsByWeek(
+              _workouts,
+            ).map((week) => _WorkoutWeekSection(week: week)),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _loadWorkouts({bool showLoading = true}) async {
+    if (showLoading && mounted) {
+      setState(() {
+        _isLoading = true;
+        _errorMessage = null;
+      });
+    }
+
+    try {
+      final workouts = await TrainingPlansService.instance
+          .getTrainingPlanWorkouts(widget.plan.id);
+
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _workouts = workouts;
+        _isLoading = false;
+        _errorMessage = null;
+      });
+    } catch (e) {
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _isLoading = false;
+        _errorMessage = e.toString();
+      });
+    }
+  }
+
+  Future<void> _openImportSheet() async {
+    final imported = await showModalBottomSheet<bool>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      builder: (context) => TrainingPlanImportSheet(plan: widget.plan),
+    );
+
+    if (!mounted || imported != true) {
+      return;
+    }
+
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(const SnackBar(content: Text('Training plan imported.')));
+  }
+
+  List<_WorkoutWeek> _groupWorkoutsByWeek(List<TrainingPlanWorkout> workouts) {
+    final sorted = [...workouts]
+      ..sort((a, b) => a.sequenceIndex.compareTo(b.sequenceIndex));
+
+    final grouped = <int, List<TrainingPlanWorkout>>{};
+
+    for (final workout in sorted) {
+      final sequenceIndex = workout.sequenceIndex <= 0
+          ? 1
+          : workout.sequenceIndex;
+      final weekNumber = ((sequenceIndex - 1) ~/ 7) + 1;
+      grouped
+          .putIfAbsent(weekNumber, () => <TrainingPlanWorkout>[])
+          .add(workout);
+    }
+
+    final weekEntries = grouped.entries.toList()
+      ..sort((a, b) => a.key.compareTo(b.key));
+
+    return weekEntries
+        .map(
+          (entry) => _WorkoutWeek(weekNumber: entry.key, workouts: entry.value),
+        )
+        .toList();
+  }
+}
+
+class _WorkoutWeek {
+  final int weekNumber;
+  final List<TrainingPlanWorkout> workouts;
+
+  const _WorkoutWeek({required this.weekNumber, required this.workouts});
+}
+
+class _WorkoutWeekSection extends StatelessWidget {
+  final _WorkoutWeek week;
+
+  const _WorkoutWeekSection({required this.week});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 16),
+      child: Card(
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Week ${week.weekNumber}',
+                style: Theme.of(
+                  context,
+                ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: 10),
+              ...week.workouts.map((workout) {
+                final sequenceIndex = workout.sequenceIndex <= 0
+                    ? 1
+                    : workout.sequenceIndex;
+                final dayNumber = ((sequenceIndex - 1) % 7) + 1;
+
+                return Container(
+                  margin: const EdgeInsets.only(bottom: 10),
+                  padding: const EdgeInsets.all(10),
+                  decoration: BoxDecoration(
+                    color: Theme.of(context).colorScheme.surfaceContainerLow,
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          Container(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 8,
+                              vertical: 4,
+                            ),
+                            decoration: BoxDecoration(
+                              color: Theme.of(
+                                context,
+                              ).colorScheme.primaryContainer,
+                              borderRadius: BorderRadius.circular(999),
+                            ),
+                            child: Text(
+                              'Day $dayNumber',
+                              style: TextStyle(
+                                color: Theme.of(
+                                  context,
+                                ).colorScheme.onPrimaryContainer,
+                                fontWeight: FontWeight.w600,
+                                fontSize: 12,
+                              ),
+                            ),
+                          ),
+                          const SizedBox(width: 8),
+                          Expanded(
+                            child: Text(
+                              workout.title,
+                              style: Theme.of(context).textTheme.titleSmall
+                                  ?.copyWith(fontWeight: FontWeight.w600),
+                            ),
+                          ),
+                        ],
+                      ),
+                      if (workout.description != null &&
+                          workout.description!.isNotEmpty) ...[
+                        const SizedBox(height: 6),
+                        Text(
+                          workout.description!,
+                          style: Theme.of(context).textTheme.bodySmall
+                              ?.copyWith(
+                                color: Theme.of(context).colorScheme.outline,
+                              ),
+                        ),
+                      ],
+                      const SizedBox(height: 8),
+                      Wrap(
+                        spacing: 8,
+                        runSpacing: 8,
+                        children: [
+                          _MetricChip(
+                            icon: Icons.category,
+                            label: workout.type.replaceAll('_', ' '),
+                          ),
+                          if (workout.plannedDurationS != null)
+                            _MetricChip(
+                              icon: Icons.schedule,
+                              label:
+                                  '${(workout.plannedDurationS! / 60).round()} min',
+                            ),
+                          if (workout.plannedDistanceM != null)
+                            _MetricChip(
+                              icon: Icons.straighten,
+                              label:
+                                  '${(workout.plannedDistanceM! / 1000).toStringAsFixed(1)} km',
+                            ),
+                          if (workout.plannedElevationGainM != null)
+                            _MetricChip(
+                              icon: Icons.terrain,
+                              label:
+                                  '${workout.plannedElevationGainM!.toStringAsFixed(0)} m',
+                            ),
+                        ],
+                      ),
+                    ],
+                  ),
+                );
+              }),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MetricChip extends StatelessWidget {
+  final IconData icon;
+  final String label;
+
+  const _MetricChip({required this.icon, required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: Theme.of(context).dividerColor),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [Icon(icon, size: 14), const SizedBox(width: 4), Text(label)],
+      ),
+    );
+  }
+}
+
+class _InfoPill extends StatelessWidget {
+  final IconData icon;
+  final String label;
+
+  const _InfoPill({required this.icon, required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceContainer,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [Icon(icon, size: 14), const SizedBox(width: 4), Text(label)],
+      ),
+    );
+  }
+}

--- a/app/lib/screens/training_plan_import_sheet.dart
+++ b/app/lib/screens/training_plan_import_sheet.dart
@@ -1,0 +1,776 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../models/training_plan.dart';
+import '../services/training_plans_service.dart';
+
+class TrainingPlanImportSheet extends StatefulWidget {
+  final TrainingPlan plan;
+
+  const TrainingPlanImportSheet({super.key, required this.plan});
+
+  @override
+  State<TrainingPlanImportSheet> createState() =>
+      _TrainingPlanImportSheetState();
+}
+
+class _TrainingPlanImportSheetState extends State<TrainingPlanImportSheet> {
+  final _formKey = GlobalKey<FormState>();
+  final DateFormat _dateLabelFormat = DateFormat('EEE, MMM d, yyyy');
+  final DateFormat _timeLabelFormat = DateFormat('h:mm a');
+  final TextEditingController _titleController = TextEditingController();
+  final TextEditingController _descriptionController = TextEditingController();
+
+  late DateTime _startDate;
+  late int _selectedWorkoutsPerWeek;
+
+  Timer? _previewDebounce;
+
+  TrainingPlanPreviewResponse? _previewResponse;
+  bool _isPreviewLoading = false;
+  bool _isImporting = false;
+
+  String? _previewError;
+  String? _submitError;
+
+  @override
+  void initState() {
+    super.initState();
+    _startDate = DateTime.now();
+    _selectedWorkoutsPerWeek = widget.plan.recommendedWorkoutsPerWeek.clamp(
+      1,
+      7,
+    );
+
+    _titleController.text = widget.plan.title;
+    _descriptionController.text = widget.plan.description ?? '';
+
+    _titleController.addListener(_schedulePreviewRequest);
+    _descriptionController.addListener(_schedulePreviewRequest);
+
+    _schedulePreviewRequest();
+  }
+
+  @override
+  void dispose() {
+    _previewDebounce?.cancel();
+    _titleController.removeListener(_schedulePreviewRequest);
+    _descriptionController.removeListener(_schedulePreviewRequest);
+    _titleController.dispose();
+    _descriptionController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final previewItems = _buildPreviewItems();
+    final groupedPreviewItems = _groupPreviewItemsByDate(previewItems);
+
+    return SafeArea(
+      child: SizedBox(
+        height: MediaQuery.of(context).size.height * 0.9,
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              _buildHeader(context),
+              if (_isPreviewLoading)
+                const LinearProgressIndicator(minHeight: 2),
+              Expanded(
+                child: ListView(
+                  padding: const EdgeInsets.all(16),
+                  children: [
+                    _buildFormFields(context),
+                    const SizedBox(height: 16),
+                    _buildSummaryCards(previewItems),
+                    const SizedBox(height: 16),
+                    _buildPreviewSection(context, groupedPreviewItems),
+                    if (_submitError != null) ...[
+                      const SizedBox(height: 16),
+                      Container(
+                        width: double.infinity,
+                        padding: const EdgeInsets.all(12),
+                        decoration: BoxDecoration(
+                          color: Theme.of(context).colorScheme.errorContainer,
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        child: Text(
+                          _submitError!,
+                          style: TextStyle(
+                            color: Theme.of(
+                              context,
+                            ).colorScheme.onErrorContainer,
+                            fontWeight: FontWeight.w500,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+              _buildFooter(context),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 16, 8, 8),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Import Plan',
+                  style: Theme.of(
+                    context,
+                  ).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  widget.plan.title,
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Theme.of(context).colorScheme.outline,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          IconButton(
+            onPressed: _isImporting ? null : () => Navigator.of(context).pop(),
+            icon: const Icon(Icons.close),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildFormFields(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Modify Before Import',
+              style: Theme.of(
+                context,
+              ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+            ),
+            const SizedBox(height: 12),
+            Text('Start Date', style: Theme.of(context).textTheme.labelLarge),
+            const SizedBox(height: 6),
+            OutlinedButton.icon(
+              onPressed: _isImporting ? null : _pickStartDate,
+              icon: const Icon(Icons.calendar_today),
+              label: Text(_dateLabelFormat.format(_startDate)),
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'Workouts Per Week',
+              style: Theme.of(context).textTheme.labelLarge,
+            ),
+            const SizedBox(height: 6),
+            Row(
+              children: [
+                IconButton(
+                  onPressed: _isImporting
+                      ? null
+                      : () => _updateWorkoutsPerWeek(
+                          _selectedWorkoutsPerWeek - 1,
+                        ),
+                  icon: const Icon(Icons.remove_circle_outline),
+                ),
+                Text(
+                  '$_selectedWorkoutsPerWeek',
+                  style: Theme.of(context).textTheme.titleLarge,
+                ),
+                IconButton(
+                  onPressed: _isImporting
+                      ? null
+                      : () => _updateWorkoutsPerWeek(
+                          _selectedWorkoutsPerWeek + 1,
+                        ),
+                  icon: const Icon(Icons.add_circle_outline),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'Recommended: ${widget.plan.recommendedWorkoutsPerWeek}',
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context).colorScheme.outline,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            TextFormField(
+              controller: _titleController,
+              decoration: const InputDecoration(
+                labelText: 'Title',
+                border: OutlineInputBorder(),
+              ),
+              textInputAction: TextInputAction.next,
+              enabled: !_isImporting,
+              validator: (value) {
+                if (value == null || value.trim().isEmpty) {
+                  return 'Title is required';
+                }
+                return null;
+              },
+            ),
+            const SizedBox(height: 12),
+            TextFormField(
+              controller: _descriptionController,
+              decoration: const InputDecoration(
+                labelText: 'Description',
+                border: OutlineInputBorder(),
+              ),
+              minLines: 3,
+              maxLines: 4,
+              enabled: !_isImporting,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSummaryCards(List<_PreviewAgendaItem> previewItems) {
+    var importCount = 0;
+    var plannedCount = 0;
+    var completedCount = 0;
+
+    for (final item in previewItems) {
+      switch (item.kind) {
+        case _PreviewItemKind.imported:
+          importCount += 1;
+        case _PreviewItemKind.planned:
+          plannedCount += 1;
+        case _PreviewItemKind.completed:
+          completedCount += 1;
+      }
+    }
+
+    return Row(
+      children: [
+        Expanded(
+          child: _SummaryTile(
+            label: 'Import',
+            value: importCount,
+            icon: Icons.download,
+          ),
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: _SummaryTile(
+            label: 'Planned',
+            value: plannedCount,
+            icon: Icons.event_note,
+          ),
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: _SummaryTile(
+            label: 'Completed',
+            value: completedCount,
+            icon: Icons.check_circle_outline,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildPreviewSection(
+    BuildContext context,
+    Map<DateTime, List<_PreviewAgendaItem>> groupedPreviewItems,
+  ) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Preview',
+              style: Theme.of(
+                context,
+              ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+            ),
+            const SizedBox(height: 8),
+            if (_previewError != null)
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.errorContainer,
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Text(
+                  _previewError!,
+                  style: TextStyle(
+                    color: Theme.of(context).colorScheme.onErrorContainer,
+                  ),
+                ),
+              )
+            else if (_isPreviewLoading && _previewResponse == null)
+              const Padding(
+                padding: EdgeInsets.symmetric(vertical: 24),
+                child: Center(child: CircularProgressIndicator()),
+              )
+            else if (groupedPreviewItems.isEmpty)
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 16),
+                child: Text(
+                  'Adjust import settings to load preview items.',
+                  style: Theme.of(context).textTheme.bodyMedium,
+                ),
+              )
+            else
+              ...groupedPreviewItems.entries.map((entry) {
+                final day = entry.key;
+                final items = entry.value;
+
+                return Padding(
+                  padding: const EdgeInsets.only(bottom: 12),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        DateFormat('EEE, MMM d').format(day),
+                        style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      ...items.map(
+                        (item) => _PreviewRow(
+                          title: item.title,
+                          subtitle:
+                              '${item.typeLabel} • ${_timeLabelFormat.format(item.startTime.toLocal())}',
+                          kind: item.kind,
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              }),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFooter(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+      decoration: BoxDecoration(
+        border: Border(top: BorderSide(color: Theme.of(context).dividerColor)),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: OutlinedButton(
+              onPressed: _isImporting
+                  ? null
+                  : () => Navigator.of(context).pop(),
+              child: const Text('Cancel'),
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: ElevatedButton(
+              onPressed: _isImporting ? null : _submitImport,
+              child: _isImporting
+                  ? const SizedBox(
+                      height: 18,
+                      width: 18,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Text('Import Plan'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _pickStartDate() async {
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: _startDate,
+      firstDate: DateTime.now().subtract(const Duration(days: 365)),
+      lastDate: DateTime.now().add(const Duration(days: 3650)),
+    );
+
+    if (picked == null || !mounted) {
+      return;
+    }
+
+    setState(() {
+      _startDate = picked;
+    });
+    _schedulePreviewRequest();
+  }
+
+  void _updateWorkoutsPerWeek(int value) {
+    final clamped = value.clamp(1, 7);
+    if (clamped == _selectedWorkoutsPerWeek) {
+      return;
+    }
+
+    setState(() {
+      _selectedWorkoutsPerWeek = clamped;
+    });
+    _schedulePreviewRequest();
+  }
+
+  void _schedulePreviewRequest() {
+    _previewDebounce?.cancel();
+    _previewDebounce = Timer(const Duration(milliseconds: 250), _loadPreview);
+  }
+
+  Future<void> _loadPreview() async {
+    if (!mounted) {
+      return;
+    }
+
+    setState(() {
+      _isPreviewLoading = true;
+      _previewError = null;
+    });
+
+    try {
+      final response = await TrainingPlansService.instance
+          .importTrainingPlanDryRun(
+            widget.plan.id,
+            ImportTrainingPlanDryRunRequest(
+              startDate: _buildStartDateWithLocalHour(_startDate),
+              selectedWorkoutsPerWeek: _selectedWorkoutsPerWeek,
+              title: _titleController.text.trim().isEmpty
+                  ? null
+                  : _titleController.text.trim(),
+              description: _descriptionController.text.trim().isEmpty
+                  ? null
+                  : _descriptionController.text.trim(),
+            ),
+          );
+
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _previewResponse = response;
+      });
+    } catch (e) {
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _previewError = e.toString();
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isPreviewLoading = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _submitImport() async {
+    final formValid = _formKey.currentState?.validate() ?? false;
+    if (!formValid) {
+      return;
+    }
+
+    if (_selectedWorkoutsPerWeek < 1 || _selectedWorkoutsPerWeek > 7) {
+      setState(() {
+        _submitError = 'Workouts per week must be between 1 and 7.';
+      });
+      return;
+    }
+
+    setState(() {
+      _submitError = null;
+      _isImporting = true;
+    });
+
+    try {
+      await TrainingPlansService.instance.importTrainingPlan(
+        widget.plan.id,
+        ImportTrainingPlanRequest(
+          startDate: _buildStartDateWithLocalHour(_startDate),
+          selectedWorkoutsPerWeek: _selectedWorkoutsPerWeek,
+          title: _titleController.text.trim(),
+          description: _descriptionController.text.trim().isEmpty
+              ? null
+              : _descriptionController.text.trim(),
+        ),
+      );
+
+      if (!mounted) {
+        return;
+      }
+
+      Navigator.of(context).pop(true);
+    } catch (e) {
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _submitError = e.toString();
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isImporting = false;
+        });
+      }
+    }
+  }
+
+  DateTime _buildStartDateWithLocalHour(DateTime baseDate) {
+    return DateTime(baseDate.year, baseDate.month, baseDate.day, 9);
+  }
+
+  List<_PreviewAgendaItem> _buildPreviewItems() {
+    if (_previewResponse == null) {
+      return [];
+    }
+
+    final items = <_PreviewAgendaItem>[];
+
+    for (final activity in _previewResponse!.activities) {
+      items.add(
+        _PreviewAgendaItem(
+          title: activity.title,
+          typeLabel: activity.type.replaceAll('_', ' '),
+          startTime: activity.startTime,
+          kind: _PreviewItemKind.completed,
+        ),
+      );
+    }
+
+    for (final planned in _previewResponse!.plannedActivities) {
+      if (planned.matchedActivityId != null) {
+        continue;
+      }
+
+      items.add(
+        _PreviewAgendaItem(
+          title: planned.title,
+          typeLabel: planned.type.replaceAll('_', ' '),
+          startTime: planned.startTime,
+          kind: planned.isDryRun
+              ? _PreviewItemKind.imported
+              : _PreviewItemKind.planned,
+        ),
+      );
+    }
+
+    items.sort((a, b) => a.startTime.compareTo(b.startTime));
+    return items;
+  }
+
+  Map<DateTime, List<_PreviewAgendaItem>> _groupPreviewItemsByDate(
+    List<_PreviewAgendaItem> items,
+  ) {
+    final grouped = <DateTime, List<_PreviewAgendaItem>>{};
+
+    for (final item in items) {
+      final local = item.startTime.toLocal();
+      final dayKey = DateTime(local.year, local.month, local.day);
+
+      final bucket = grouped.putIfAbsent(dayKey, () => <_PreviewAgendaItem>[]);
+      bucket.add(item);
+    }
+
+    final sortedEntries = grouped.entries.toList()
+      ..sort((a, b) => a.key.compareTo(b.key));
+
+    return {for (final entry in sortedEntries) entry.key: entry.value};
+  }
+}
+
+enum _PreviewItemKind { imported, planned, completed }
+
+class _PreviewAgendaItem {
+  final String title;
+  final String typeLabel;
+  final DateTime startTime;
+  final _PreviewItemKind kind;
+
+  const _PreviewAgendaItem({
+    required this.title,
+    required this.typeLabel,
+    required this.startTime,
+    required this.kind,
+  });
+}
+
+class _SummaryTile extends StatelessWidget {
+  final String label;
+  final int value;
+  final IconData icon;
+
+  const _SummaryTile({
+    required this.label,
+    required this.value,
+    required this.icon,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceContainerHigh,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        children: [
+          Icon(icon, size: 16),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '$value',
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                Text(label, style: Theme.of(context).textTheme.bodySmall),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PreviewRow extends StatelessWidget {
+  final String title;
+  final String subtitle;
+  final _PreviewItemKind kind;
+
+  const _PreviewRow({
+    required this.title,
+    required this.subtitle,
+    required this.kind,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final kindMeta = _buildMeta(context);
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 8),
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: kindMeta.background,
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Row(
+        children: [
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+            decoration: BoxDecoration(
+              color: kindMeta.badge,
+              borderRadius: BorderRadius.circular(999),
+            ),
+            child: Text(
+              kindMeta.label,
+              style: TextStyle(
+                color: kindMeta.badgeText,
+                fontSize: 11,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: Theme.of(
+                    context,
+                  ).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w600),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  subtitle,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context).colorScheme.outline,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  _PreviewKindMeta _buildMeta(BuildContext context) {
+    switch (kind) {
+      case _PreviewItemKind.imported:
+        return _PreviewKindMeta(
+          label: 'Import',
+          background: Theme.of(context).colorScheme.primaryContainer,
+          badge: Theme.of(context).colorScheme.primary,
+          badgeText: Theme.of(context).colorScheme.onPrimary,
+        );
+      case _PreviewItemKind.planned:
+        return _PreviewKindMeta(
+          label: 'Planned',
+          background: Theme.of(context).colorScheme.surfaceContainer,
+          badge: Theme.of(context).colorScheme.outline,
+          badgeText: Theme.of(context).colorScheme.onPrimary,
+        );
+      case _PreviewItemKind.completed:
+        return _PreviewKindMeta(
+          label: 'Completed',
+          background: Theme.of(context).colorScheme.secondaryContainer,
+          badge: Theme.of(context).colorScheme.secondary,
+          badgeText: Theme.of(context).colorScheme.onSecondary,
+        );
+    }
+  }
+}
+
+class _PreviewKindMeta {
+  final String label;
+  final Color background;
+  final Color badge;
+  final Color badgeText;
+
+  const _PreviewKindMeta({
+    required this.label,
+    required this.background,
+    required this.badge,
+    required this.badgeText,
+  });
+}

--- a/app/lib/screens/training_plans_screen.dart
+++ b/app/lib/screens/training_plans_screen.dart
@@ -1,0 +1,301 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../models/training_plan.dart';
+import '../services/training_plans_service.dart';
+import '../widgets/global/empty_state_widget.dart';
+import '../widgets/global/error_state_widget.dart';
+import '../widgets/global/loading_indicator.dart';
+import 'training_plan_detail_screen.dart';
+
+class TrainingPlansScreen extends StatefulWidget {
+  const TrainingPlansScreen({super.key});
+
+  @override
+  State<TrainingPlansScreen> createState() => _TrainingPlansScreenState();
+}
+
+class _TrainingPlansScreenState extends State<TrainingPlansScreen> {
+  final TextEditingController _searchController = TextEditingController();
+
+  Timer? _searchDebounce;
+
+  bool _isLoading = true;
+  String? _errorMessage;
+
+  List<TrainingPlan> _plans = [];
+  TrainingPlanActivityTypeFilter _activityType =
+      TrainingPlanActivityTypeFilter.all;
+
+  @override
+  void initState() {
+    super.initState();
+    _searchController.addListener(_onSearchChanged);
+    _loadTrainingPlans();
+  }
+
+  @override
+  void dispose() {
+    _searchDebounce?.cancel();
+    _searchController.removeListener(_onSearchChanged);
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text(
+          'Training Plans',
+          style: TextStyle(fontWeight: FontWeight.bold),
+        ),
+        actions: [
+          IconButton(
+            onPressed: _isLoading ? null : () => _loadTrainingPlans(),
+            icon: const Icon(Icons.refresh),
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          _buildSearchAndFilterBar(context),
+          Expanded(child: _buildBody()),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSearchAndFilterBar(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+      child: Column(
+        children: [
+          TextField(
+            controller: _searchController,
+            decoration: InputDecoration(
+              hintText: 'Search plans',
+              prefixIcon: const Icon(Icons.search),
+              suffixIcon: _searchController.text.isNotEmpty
+                  ? IconButton(
+                      onPressed: () {
+                        _searchController.clear();
+                        _loadTrainingPlans();
+                      },
+                      icon: const Icon(Icons.close),
+                    )
+                  : null,
+              border: const OutlineInputBorder(),
+              isDense: true,
+            ),
+          ),
+          const SizedBox(height: 10),
+          SizedBox(
+            height: 36,
+            child: ListView(
+              scrollDirection: Axis.horizontal,
+              children: [
+                _buildFilterChip(TrainingPlanActivityTypeFilter.all),
+                _buildFilterChip(TrainingPlanActivityTypeFilter.running),
+                _buildFilterChip(TrainingPlanActivityTypeFilter.roadBiking),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildFilterChip(TrainingPlanActivityTypeFilter filter) {
+    return Padding(
+      padding: const EdgeInsets.only(right: 8),
+      child: ChoiceChip(
+        label: Text(filter.label),
+        selected: _activityType == filter,
+        onSelected: (isSelected) {
+          if (!isSelected || _activityType == filter) {
+            return;
+          }
+
+          setState(() {
+            _activityType = filter;
+          });
+
+          _loadTrainingPlans();
+        },
+      ),
+    );
+  }
+
+  Widget _buildBody() {
+    if (_isLoading) {
+      return const LoadingIndicator();
+    }
+
+    if (_errorMessage != null) {
+      return ErrorStateWidget(
+        message: _errorMessage,
+        onRetry: _loadTrainingPlans,
+      );
+    }
+
+    if (_plans.isEmpty) {
+      return const EmptyStateWidget(
+        icon: Icons.event_note,
+        title: 'No training plans found',
+        message: 'Try another query or activity type.',
+      );
+    }
+
+    return RefreshIndicator(
+      onRefresh: () => _loadTrainingPlans(showLoading: false),
+      child: ListView.builder(
+        padding: const EdgeInsets.fromLTRB(16, 8, 16, 90),
+        itemCount: _plans.length,
+        itemBuilder: (context, index) {
+          final plan = _plans[index];
+
+          return Padding(
+            padding: const EdgeInsets.only(bottom: 10),
+            child: Card(
+              child: InkWell(
+                borderRadius: BorderRadius.circular(12),
+                onTap: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (context) =>
+                          TrainingPlanDetailScreen(plan: plan),
+                    ),
+                  );
+                },
+                child: Padding(
+                  padding: const EdgeInsets.all(12),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          Icon(
+                            plan.primaryActivityType == 'road_biking'
+                                ? Icons.directions_bike
+                                : Icons.directions_run,
+                          ),
+                          const SizedBox(width: 8),
+                          Expanded(
+                            child: Text(
+                              plan.title,
+                              style: Theme.of(context).textTheme.titleMedium
+                                  ?.copyWith(fontWeight: FontWeight.w700),
+                            ),
+                          ),
+                        ],
+                      ),
+                      if (plan.description != null &&
+                          plan.description!.trim().isNotEmpty) ...[
+                        const SizedBox(height: 8),
+                        Text(
+                          plan.description!,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          style: Theme.of(context).textTheme.bodyMedium
+                              ?.copyWith(
+                                color: Theme.of(context).colorScheme.outline,
+                              ),
+                        ),
+                      ],
+                      const SizedBox(height: 10),
+                      Wrap(
+                        spacing: 8,
+                        runSpacing: 8,
+                        children: [
+                          _PlanMetaChip(
+                            icon: Icons.calendar_view_week,
+                            label: '${plan.durationWeeks} weeks',
+                          ),
+                          _PlanMetaChip(
+                            icon: Icons.fitness_center,
+                            label: '${plan.recommendedWorkoutsPerWeek}/week',
+                          ),
+                          _PlanMetaChip(
+                            icon: Icons.trending_up,
+                            label: plan.difficulty,
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  void _onSearchChanged() {
+    _searchDebounce?.cancel();
+    _searchDebounce = Timer(
+      const Duration(milliseconds: 300),
+      () => _loadTrainingPlans(),
+    );
+  }
+
+  Future<void> _loadTrainingPlans({bool showLoading = true}) async {
+    if (showLoading && mounted) {
+      setState(() {
+        _isLoading = true;
+        _errorMessage = null;
+      });
+    }
+
+    try {
+      final plans = await TrainingPlansService.instance.getTrainingPlans(
+        query: _searchController.text,
+        activityType: _activityType,
+      );
+
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _plans = plans;
+        _isLoading = false;
+        _errorMessage = null;
+      });
+    } catch (e) {
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _isLoading = false;
+        _errorMessage = e.toString();
+      });
+    }
+  }
+}
+
+class _PlanMetaChip extends StatelessWidget {
+  final IconData icon;
+  final String label;
+
+  const _PlanMetaChip({required this.icon, required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceContainer,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [Icon(icon, size: 14), const SizedBox(width: 4), Text(label)],
+      ),
+    );
+  }
+}

--- a/app/lib/services/training_plans_service.dart
+++ b/app/lib/services/training_plans_service.dart
@@ -1,0 +1,183 @@
+import 'dart:developer';
+
+import 'package:dio/dio.dart';
+
+import '../models/training_plan.dart';
+import 'http_client.dart';
+
+class TrainingPlansServiceException implements Exception {
+  final String message;
+
+  const TrainingPlansServiceException(this.message);
+
+  @override
+  String toString() => message;
+}
+
+class TrainingPlansService {
+  TrainingPlansService._();
+
+  static final TrainingPlansService instance = TrainingPlansService._();
+
+  Future<List<TrainingPlan>> getTrainingPlans({
+    String? query,
+    TrainingPlanActivityTypeFilter activityType =
+        TrainingPlanActivityTypeFilter.all,
+  }) async {
+    try {
+      final queryParams = <String, dynamic>{};
+      final normalizedQuery = query?.trim();
+
+      if (normalizedQuery != null && normalizedQuery.isNotEmpty) {
+        queryParams['q'] = normalizedQuery;
+      }
+      if (activityType != TrainingPlanActivityTypeFilter.all) {
+        queryParams['activity_type'] = activityType.apiValue;
+      }
+
+      final response = await HttpClient.instance.dio.get(
+        '/api/v1/training-plans',
+        queryParameters: queryParams,
+      );
+
+      if (response.statusCode != 200 || response.data is! List<dynamic>) {
+        throw const TrainingPlansServiceException(
+          'Failed to load training plans.',
+        );
+      }
+
+      return (response.data as List<dynamic>)
+          .whereType<Map<String, dynamic>>()
+          .map(TrainingPlan.fromJson)
+          .toList();
+    } on DioException catch (e) {
+      log('Error fetching training plans: $e');
+      throw TrainingPlansServiceException(_extractErrorMessage(e));
+    } catch (e) {
+      log('Error fetching training plans: $e');
+      if (e is TrainingPlansServiceException) {
+        rethrow;
+      }
+      throw const TrainingPlansServiceException(
+        'Failed to load training plans.',
+      );
+    }
+  }
+
+  Future<List<TrainingPlanWorkout>> getTrainingPlanWorkouts(
+    String planId,
+  ) async {
+    try {
+      final response = await HttpClient.instance.dio.get(
+        '/api/v1/training-plans/$planId/workouts',
+      );
+
+      if (response.statusCode != 200 || response.data is! List<dynamic>) {
+        throw const TrainingPlansServiceException(
+          'Failed to load training plan workouts.',
+        );
+      }
+
+      return (response.data as List<dynamic>)
+          .whereType<Map<String, dynamic>>()
+          .map(TrainingPlanWorkout.fromJson)
+          .toList();
+    } on DioException catch (e) {
+      log('Error fetching training plan workouts: $e');
+      throw TrainingPlansServiceException(_extractErrorMessage(e));
+    } catch (e) {
+      log('Error fetching training plan workouts: $e');
+      if (e is TrainingPlansServiceException) {
+        rethrow;
+      }
+      throw const TrainingPlansServiceException(
+        'Failed to load training plan workouts.',
+      );
+    }
+  }
+
+  Future<TrainingPlanPreviewResponse> importTrainingPlanDryRun(
+    String planId,
+    ImportTrainingPlanDryRunRequest request,
+  ) async {
+    try {
+      final response = await HttpClient.instance.dio.post(
+        '/api/v1/training-plans/$planId/import/dry-run',
+        data: request.toJson(),
+      );
+
+      if (response.statusCode != 200 ||
+          response.data is! Map<String, dynamic>) {
+        throw const TrainingPlansServiceException(
+          'Failed to build import preview.',
+        );
+      }
+
+      return TrainingPlanPreviewResponse.fromJson(
+        response.data as Map<String, dynamic>,
+      );
+    } on DioException catch (e) {
+      log('Error running training plan dry-run: $e');
+      throw TrainingPlansServiceException(_extractErrorMessage(e));
+    } catch (e) {
+      log('Error running training plan dry-run: $e');
+      if (e is TrainingPlansServiceException) {
+        rethrow;
+      }
+      throw const TrainingPlansServiceException(
+        'Failed to build import preview.',
+      );
+    }
+  }
+
+  Future<ImportTrainingPlanResponse> importTrainingPlan(
+    String planId,
+    ImportTrainingPlanRequest request,
+  ) async {
+    try {
+      final response = await HttpClient.instance.dio.post(
+        '/api/v1/training-plans/$planId/import',
+        data: request.toJson(),
+      );
+
+      if ((response.statusCode != 200 && response.statusCode != 201) ||
+          response.data is! Map<String, dynamic>) {
+        throw const TrainingPlansServiceException(
+          'Failed to import training plan.',
+        );
+      }
+
+      return ImportTrainingPlanResponse.fromJson(
+        response.data as Map<String, dynamic>,
+      );
+    } on DioException catch (e) {
+      log('Error importing training plan: $e');
+      throw TrainingPlansServiceException(_extractErrorMessage(e));
+    } catch (e) {
+      log('Error importing training plan: $e');
+      if (e is TrainingPlansServiceException) {
+        rethrow;
+      }
+      throw const TrainingPlansServiceException(
+        'Failed to import training plan.',
+      );
+    }
+  }
+
+  String _extractErrorMessage(DioException error) {
+    final responseData = error.response?.data;
+    if (responseData is Map<String, dynamic>) {
+      final message = responseData['error'];
+      if (message is String && message.trim().isNotEmpty) {
+        return message;
+      }
+    }
+
+    final rawMessage = error.message;
+    if (rawMessage != null && rawMessage.trim().isNotEmpty) {
+      return rawMessage;
+    }
+
+    return 'Request failed. Please try again.';
+  }
+}

--- a/app/lib/utils/app_theme.dart
+++ b/app/lib/utils/app_theme.dart
@@ -1,4 +1,3 @@
-
 import 'package:flutter/material.dart';
 import 'app_spacing.dart';
 import 'app_text_size.dart';
@@ -9,12 +8,10 @@ class AppTheme {
     colorScheme: ColorScheme.fromSeed(
       seedColor: AppColors.primaryBlue,
       brightness: Brightness.light,
-    ).copyWith(
-      primary: AppColors.primaryBlue,
-    ),
+    ).copyWith(primary: AppColors.primaryBlue),
     primaryColor: AppColors.primaryBlue,
     useMaterial3: true,
-    
+
     // Text field styling
     inputDecorationTheme: InputDecorationTheme(
       filled: true,
@@ -49,13 +46,13 @@ class AppTheme {
         fontWeight: AppTextSize.medium,
       ),
     ),
-    
+
     // Elevated button styling
     elevatedButtonTheme: ElevatedButtonThemeData(
       style: ElevatedButton.styleFrom(
         backgroundColor: AppColors.primaryBlue,
         foregroundColor: Colors.white,
-        minimumSize: Size(double.infinity, AppSpacing.huge),
+        minimumSize: const Size(0, AppSpacing.huge),
         padding: AppSpacing.paddingHorizontalXL,
         shape: RoundedRectangleBorder(
           borderRadius: AppSpacing.borderRadiusFull,
@@ -67,7 +64,7 @@ class AppTheme {
         elevation: AppSpacing.elevationXS,
       ),
     ),
-    
+
     // Text button styling
     textButtonTheme: TextButtonThemeData(
       style: TextButton.styleFrom(
@@ -78,12 +75,12 @@ class AppTheme {
         ),
       ),
     ),
-    
+
     // Outlined button styling
     outlinedButtonTheme: OutlinedButtonThemeData(
       style: OutlinedButton.styleFrom(
         foregroundColor: AppColors.primaryBlue,
-        minimumSize: Size(double.infinity, AppSpacing.huge),
+        minimumSize: const Size(0, AppSpacing.huge),
         padding: AppSpacing.paddingHorizontalXL,
         shape: RoundedRectangleBorder(
           borderRadius: AppSpacing.borderRadiusFull,
@@ -101,12 +98,10 @@ class AppTheme {
     colorScheme: ColorScheme.fromSeed(
       seedColor: AppColors.primaryBlue,
       brightness: Brightness.dark,
-    ).copyWith(
-      primary: AppColors.primaryBlue,
-    ),
+    ).copyWith(primary: AppColors.primaryBlue),
     primaryColor: AppColors.primaryBlue,
     useMaterial3: true,
-    
+
     // Text field styling for dark mode
     inputDecorationTheme: InputDecorationTheme(
       filled: true,
@@ -141,13 +136,13 @@ class AppTheme {
         fontWeight: AppTextSize.medium,
       ),
     ),
-    
+
     // Elevated button styling for dark mode
     elevatedButtonTheme: ElevatedButtonThemeData(
       style: ElevatedButton.styleFrom(
         backgroundColor: AppColors.primaryBlue,
         foregroundColor: Colors.white,
-        minimumSize: Size(double.infinity, AppSpacing.huge),
+        minimumSize: const Size(0, AppSpacing.huge),
         padding: AppSpacing.paddingHorizontalXL,
         shape: RoundedRectangleBorder(
           borderRadius: AppSpacing.borderRadiusFull,
@@ -159,7 +154,7 @@ class AppTheme {
         elevation: AppSpacing.elevationXS,
       ),
     ),
-    
+
     // Text button styling for dark mode
     textButtonTheme: TextButtonThemeData(
       style: TextButton.styleFrom(
@@ -170,12 +165,12 @@ class AppTheme {
         ),
       ),
     ),
-    
+
     // Outlined button styling for dark mode
     outlinedButtonTheme: OutlinedButtonThemeData(
       style: OutlinedButton.styleFrom(
         foregroundColor: AppColors.primaryBlue,
-        minimumSize: Size(double.infinity, AppSpacing.huge),
+        minimumSize: const Size(0, AppSpacing.huge),
         padding: AppSpacing.paddingHorizontalXL,
         shape: RoundedRectangleBorder(
           borderRadius: AppSpacing.borderRadiusFull,
@@ -188,7 +183,7 @@ class AppTheme {
       ),
     ),
   );
-  
+
   // Helper to get map style based on theme
   static String getMapStyle(BuildContext context) {
     final brightness = Theme.of(context).brightness;

--- a/app/lib/widgets/main_layout.dart
+++ b/app/lib/widgets/main_layout.dart
@@ -1,4 +1,5 @@
 import 'package:cadent/screens/recorder_screen.dart';
+import 'package:cadent/screens/training_plans_screen.dart';
 import 'package:flutter/material.dart';
 import '../screens/home_screen.dart';
 import '../screens/settings_screen.dart';
@@ -17,6 +18,7 @@ class _MainLayoutState extends State<MainLayout> {
 
   static const List<Widget> _pages = <Widget>[
     HomeScreen(),
+    TrainingPlansScreen(),
     SettingsScreen(),
   ];
 
@@ -46,13 +48,11 @@ class _MainLayoutState extends State<MainLayout> {
           backgroundColor: Theme.of(context).colorScheme.primary,
           foregroundColor: Theme.of(context).colorScheme.onPrimary,
           shape: const CircleBorder(),
-          child: Icon(Icons.fiber_manual_record, size: AppSpacing.iconLG),
+          child: Icon(Icons.add, size: AppSpacing.iconLG),
         ),
       ),
-      floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
+      floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
       bottomNavigationBar: BottomAppBar(
-        shape: const CircularNotchedRectangle(),
-        notchMargin: AppSpacing.xxs,
         child: SizedBox(
           height: AppSpacing.massive,
           child: Row(
@@ -66,13 +66,20 @@ class _MainLayoutState extends State<MainLayout> {
                   isSelected: _selectedIndex == 0,
                 ),
               ),
-              const SizedBox(width: AppSpacing.massive), // Space for FAB
+              Expanded(
+                child: _buildNavItem(
+                  icon: Icons.event_note,
+                  label: 'Plans',
+                  index: 1,
+                  isSelected: _selectedIndex == 1,
+                ),
+              ),
               Expanded(
                 child: _buildNavItem(
                   icon: Icons.settings,
                   label: 'Settings',
-                  index: 1,
-                  isSelected: _selectedIndex == 1,
+                  index: 2,
+                  isSelected: _selectedIndex == 2,
                 ),
               ),
             ],
@@ -98,7 +105,9 @@ class _MainLayoutState extends State<MainLayout> {
           children: [
             Icon(
               icon,
-              color: isSelected ? Theme.of(context).colorScheme.primary : Theme.of(context).colorScheme.outline,
+              color: isSelected
+                  ? Theme.of(context).colorScheme.primary
+                  : Theme.of(context).colorScheme.outline,
               size: AppSpacing.iconSM,
             ),
             AppSpacing.gapXXS,
@@ -106,8 +115,12 @@ class _MainLayoutState extends State<MainLayout> {
               label,
               style: TextStyle(
                 fontSize: AppTextSize.xs,
-                color: isSelected ? Theme.of(context).colorScheme.primary : Theme.of(context).colorScheme.outline,
-                fontWeight: isSelected ? AppTextSize.semiBold : AppTextSize.regular,
+                color: isSelected
+                    ? Theme.of(context).colorScheme.primary
+                    : Theme.of(context).colorScheme.outline,
+                fontWeight: isSelected
+                    ? AppTextSize.semiBold
+                    : AppTextSize.regular,
               ),
               textAlign: TextAlign.center,
             ),

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -101,10 +101,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -540,18 +540,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -897,10 +897,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
Adds the following screens and functionality:
- training plans tab
- detailed view of a training plan and workouts
- import

screenshots:
<img width="354" height="787" alt="image" src="https://github.com/user-attachments/assets/713970e6-1017-46d9-9a11-f46b861eb0ba" />
<img width="354" height="787" alt="image" src="https://github.com/user-attachments/assets/192e27fe-f60a-4b28-b7ad-41644af00ffc" />
<img width="354" height="787" alt="image" src="https://github.com/user-attachments/assets/05ab62c3-81ea-402f-a339-bc0671bbc2db" />
